### PR TITLE
Speed up Synchronization

### DIFF
--- a/releases/releases.json
+++ b/releases/releases.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fb6f1658da36f7c70bdeaf77561a4969b804b1a5a4c7cde21dc8ff814916623
+oid sha256:df6f80e7f72cfcee0df657421b98208e21307d4442c4c694ab79b785545e7795
 size 965663

--- a/solc.go
+++ b/solc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"time"
 )
 
 // Solc represents the main structure for interacting with the Solidity compiler.
@@ -15,18 +16,10 @@ type Solc struct {
 	client        *http.Client
 	gOOSFunc      func() string
 	localReleases []Version
+	lastSync      time.Time
 }
 
 // New initializes and returns a new instance of the Solc structure.
-// It requires a context and a configuration to be provided.
-//
-// Parameters:
-// - ctx: The context for the Solc instance.
-// - config: The configuration settings for the Solc instance.
-//
-// Returns:
-// - A pointer to the initialized Solc instance.
-// - An error if there's any issue during initialization.
 func New(ctx context.Context, config *Config) (*Solc, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config needs to be provided")
@@ -47,39 +40,26 @@ func New(ctx context.Context, config *Config) (*Solc, error) {
 }
 
 // GetContext retrieves the context associated with the Solc instance.
-//
-// Returns:
-// - The context.Context of the Solc instance.
 func (s *Solc) GetContext() context.Context {
 	return s.ctx
 }
 
+// LastSyncTime retrieves the last time the Solc instance was synced.
+func (s *Solc) LastSyncTime() time.Time {
+	return s.lastSync
+}
+
 // GetConfig retrieves the configuration associated with the Solc instance.
-//
-// Returns:
-// - A pointer to the Config of the Solc instance.
 func (s *Solc) GetConfig() *Config {
 	return s.config
 }
 
 // GetHTTPClient retrieves the HTTP client associated with the Solc instance.
-//
-// Returns:
-// - A pointer to the http.Client of the Solc instance.
 func (s *Solc) GetHTTPClient() *http.Client {
 	return s.client
 }
 
 // Compile compiles the provided Solidity source code using the specified compiler configuration.
-//
-// Parameters:
-// - ctx: The context for the compilation process.
-// - source: The Solidity source code to be compiled.
-// - config: The configuration settings for the compiler.
-//
-// Returns:
-// - A pointer to the CompilerResults containing the results of the compilation.
-// - An error if there's any issue during the compilation process.
 func (s *Solc) Compile(ctx context.Context, source string, config *CompilerConfig) (*CompilerResults, error) {
 	compiler, err := NewCompiler(ctx, s, config, source)
 	if err != nil {

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -54,6 +54,7 @@ func TestSyncer(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			assert.NotNil(t, s.LastSyncTime())
 		})
 	}
 }
@@ -108,6 +109,7 @@ func TestSyncOnce(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			assert.NotNil(t, s.LastSyncTime())
 		})
 	}
 }


### PR DESCRIPTION
Until now, whenever sync was called it tried to check new releases from the github. That does not make sense and instead, should return cache back. It's hardcoded and no more then 4 times a day sync can attempt to sync from now on.

This ensures that on the run of the application, initial sync is done and afterwards if any goroutine calls it later on to attempt syncing, it won't spam Github API without any use.